### PR TITLE
Updated hipchat-php requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.5.0",
         "illuminate/support": "4.2.*",
-        "hipchat/hipchat-php": "dev-master"
+        "hipchat/hipchat-php": "~1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
dev-master is riskier, ~1.0 is better for production and works with "minimum-stability": "stable"
